### PR TITLE
v0.6.1 for use in production.

### DIFF
--- a/mws/mws.py
+++ b/mws/mws.py
@@ -18,7 +18,6 @@ from datetime import datetime
 
 from requests import request
 from requests.exceptions import HTTPError
-from dateutil.parser import parse as dt_parse
 
 
 __all__ = [
@@ -210,13 +209,13 @@ class MWS(object):
         # Remove all keys with an empty value because
         # Amazon's MWS does not allow such a thing.
         extra_data = remove_empty(extra_data)
-        now = self.get_timestamp()
+        utc_now = datetime.utcnow()
 
         params = {
             'AWSAccessKeyId': self.access_key,
             self.ACCOUNT_TYPE: self.account_id,
             'SignatureVersion': '2',
-            'Timestamp': now,
+            'Timestamp': utc_now.isoformat(),
             'Version': self.version,
             'SignatureMethod': 'HmacSHA256',
         }
@@ -279,7 +278,7 @@ class MWS(object):
         # Store the response object in the parsed_response for quick access
         parsed_response.response = response
         # MWS recommends saving timestamp, so we make it available.
-        parsed_response.timestamp = dt_parse(now)
+        parsed_response.timestamp = utc_now
         return parsed_response
 
     def get_service_status(self):

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -4,7 +4,12 @@
 # Basic interface to Amazon MWS
 # Based on http://code.google.com/p/amazon-mws-python
 
-import urllib
+# import urllib
+try:
+    from urllib import quote as url_quote
+except ImportError:
+    # Python 3 version: quote is in the parse module of urllib.
+    from urllib.parse import quote as url_quote
 import hashlib
 import hmac
 import base64
@@ -236,7 +241,7 @@ class MWS(object):
         request_description = '&'.join([
             '{key}={value}'.format(
                 key=k,
-                value=urllib.parse.quote(params[k], safe='-_.~'),
+                value=url_quote(params[k], safe='-_.~'),
             ) for k in sorted(params)
         ])
         signature = self.calc_signature(method, request_description)
@@ -244,7 +249,7 @@ class MWS(object):
             domain=self.domain,
             uri=self.uri,
             description=request_description,
-            signature=urllib.parse.quote(signature),
+            signature=url_quote(signature),
         )
         headers = {'User-Agent': 'python-amazon-mws/0.0.1 (Language=Python)'}
         headers.update(kwargs.get('extra_headers', {}))

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -90,6 +90,7 @@ def dt_iso_or_none(d):
     # none of the above: return None
     return None
 
+
 def remove_namespace(xml):
     regex = re.compile(' xmlns(:ns2)?="[^"]+"|(ns2:)|(xml:)')
     try:
@@ -128,6 +129,13 @@ class DictWrapper(object):
         Typical use: '.metadata.RequestId'
         """
         return self._response_dict.get('ResponseMetadata')
+    
+    @property
+    def request_id(self):
+        metadata = self._response_dict.get('ResponseMetadata')
+        if metadata:
+            return metadata.RequestId
+        return self._response_dict.get('RequestId')
 
 
 class DataWrapper(object):
@@ -225,7 +233,6 @@ class MWS(object):
         if self.auth_token:
             params['MWSAuthToken'] = self.auth_token
         params.update(extra_data)
-        
         request_description = '&'.join([
             '{key}={value}'.format(
                 key=k,

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -338,9 +338,11 @@ class MWS(object):
             request_description
         ])
         return base64.b64encode(
-            hmac.new(str(self.secret_key).encode('utf-8'),
-            sig_data.encode('utf-8'),
-            hashlib.sha256).digest()
+            hmac.new(
+                str(self.secret_key).encode('utf-8'),
+                sig_data.encode('utf-8'),
+                hashlib.sha256
+            ).digest()
         )
 
     def _enumerate_param(self, param, values):

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -982,21 +982,27 @@ class InboundShipments(MWS):
         if not args:
             raise MWSError("One or more item dictionary arguments REQUIRED.")
         
-        for a in args:
-            if not isinstance(a, dict):
+        for item in args:
+            if not isinstance(item, dict):
                 raise MWSError("item argument must be a dictionary.")
-            if not all(k in a for k in ('sku', 'quantity')):
+            if not all(k in item for k in ('sku', 'quantity')):
                 # Required keys of an item line missing
                 raise MWSError((
                     "item dictionary missing REQUIRED keys: 'sku', 'quantity'"
                     "\n[OPTIONAL keys: 'asin', 'condition', 'quantity_in_case']"
                 ))
+            quantity = item.get('quantity')
+            if quantity is not None:
+                quantity = str(quantity)
+            quantity_in_case = item.get('quantity_in_case')
+            if quantity_in_case is not None:
+                quantity_in_case = str(quantity_in_case)
             items.append({
-                'SellerSKU': a.get('sku'),
-                'Quantity': str(a.get('quantity')),
-                'ASIN': a.get('asin'),
-                'Condition': a.get('condition'),
-                'QuantityInCase': str(a.get('quantity_in_case')),
+                'SellerSKU': item.get('sku'),
+                'ASIN': item.get('asin'),
+                'Condition': item.get('condition'),
+                'Quantity': quantity,
+                'QuantityInCase': quantity_in_case,
             })
         
         data = dict(
@@ -1007,7 +1013,7 @@ class InboundShipments(MWS):
         )
         data.update(parsed_address)
         data.update(self.enumerate_keyed_param(
-            'InboundShipmentPlanRequestItem.member', items,
+            'InboundShipmentPlanRequestItems.member', items,
         ))
         return self.make_request(data, method="POST")
     

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -111,10 +111,13 @@ class DictWrapper(object):
 
     @property
     def parsed(self):
+        root = None
         if self._rootkey:
-            return self._response_dict.get(self._rootkey)
-        else:
-            return self._response_dict
+            root = self._response_dict.get(self._rootkey)
+        if root is None:
+            root = self._response_dict
+        
+        return root
     
     @property
     def metadata(self):

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -929,7 +929,7 @@ class InboundShipments(MWS):
         'ListInboundShipmentItems',
     ]
     
-    def create_inbound_shipment_plan(self, *args, **kwargs):
+    def create_inbound_shipment_plan(self, *args, from_address={}, **kwargs):
         """
         Returns one or more inbound shipment plans, which provide the
         information you need to create one or more inbound shipments for
@@ -937,34 +937,21 @@ class InboundShipments(MWS):
         
         One or more dictionaries must be passed as positional arguments.
         Each dictionary must contain the following keys:
-          REQUIRED:
-            sku
-            quantity
-          OPTIONAL:
-            asin
-            condition
-            quantity_in_case
+          REQUIRED: 'sku', 'quantity'
+          OPTIONAL: 'asin', 'condition', 'quantity_in_case'
         
-        `from_address`: REQUIRED keyword argument.
-        Dictionary of strings containing ShipFromAddress data
-          REQUIRED:
-            name
-            address_1
-            city
-            country
-          OPTIONAL:
-            address_2
-            state_or_province
-            district_or_county
-            postal_code
+        Keyword arguments:
+        'from_address' (required). Dictionary of strings containing
+        ShipFromAddress data
+            REQUIRED: 'name', 'address_1', 'city', 'country'
+            OPTIONAL: 'address_2', 'state_or_province',
+                      'district_or_county', 'postal_code'
         
-        Other keyword arguments accepted:
-        `country_code`      -> ShipToCountryCode
-        `subdivision_code`  -> ShipToCountrySubdivisionCode
-        `label_preference`  -> LabelPrepPreference
+        'country_code' (optional) [defaults to 'US']
+        'subdivision_code' (optional)
+        'label_preference' (optional)
         """
-        from_address = kwargs.get('from_address')
-        if from_address is None:
+        if not from_address:
             raise MWSError('Missing from_address keyword argument (Required)')
         country_code = kwargs.get('country_code', 'US')
         subdivision_code = kwargs.get('subdivision_code')
@@ -973,7 +960,7 @@ class InboundShipments(MWS):
         if not isinstance(from_address, dict):
             raise MWSError("from_address must be a dictionary")
         if not all(k in from_address
-                   for k in ('name', 'address_1', 'city', 'country')):
+                   for k in ('name', 'address_1', 'city')):
             # Required parts of from_address missing
             raise MWSError((
                 "REQUIRED keys missing from `from_address`: 'name', "
@@ -1010,10 +997,10 @@ class InboundShipments(MWS):
                 ))
             items.append({
                 'SellerSKU': a.get('sku'),
-                'Quantity': a.get('quantity'),
+                'Quantity': str(a.get('quantity')),
                 'ASIN': a.get('asin'),
                 'Condition': a.get('condition'),
-                'QuantityInCase': a.get('quantity_in_case'),
+                'QuantityInCase': str(a.get('quantity_in_case')),
             })
         
         data = dict(

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -331,12 +331,6 @@ class MWS(object):
             hashlib.sha256).digest()
         )
 
-    def get_timestamp(self):
-        """
-        Returns the current timestamp in ISO 8601 format.
-        """
-        return datetime.utcnow().isoformat()
-
     def _enumerate_param(self, param, values):
         """
         Builds a dictionary of an enumerated parameter.

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -82,15 +82,15 @@ def remove_empty(d):
 
 def dt_iso_or_none(d):
     """
-    If d is a datetime, convert to isoformat
+    If d is a datetime, return isoformat()
+    TODO: if d is a string in iso8601 already, return it back
     Otherwise, return None
     """
     # If d is a datetime object, format it to iso and return
     if isinstance(d, datetime):
         return d.isoformat()
         
-    # if d is a string in iso8601 already, return it
-    # # pass for now
+    # TODO: if d is a string in iso8601 already, return it
     
     # none of the above: return None
     return None


### PR DESCRIPTION
- Cleaned up comments in several spots.
- No longer requiring dateutil to parse datetime strings.
  - Rearranged affected code to need no conversion in the first place.
- Stripped code that called raise_for_status() in make_request()
  - There are cases where the error must be processed on the user side: calling raise_for_status() creates an exception which destroys the data that would otherwise be returned for use.
  - Let the coder handle these exceptions in the short term.
- Implemented create_inbound_shipment_plan
  - Required addition of enumerate_keyed_params() method
