### PR TITLE
Additional changes related to pull #32 on upstream

### DIFF
--- a/mws/mws.py
+++ b/mws/mws.py
@@ -367,6 +367,9 @@ class MWS(object):
         # Shortcut for empty values
         if not values:
             return {}
+            
+        if not isinstance(values, list) and not isinstance(values, tuple):
+            values = [values,]
         
         # Ensure this enumerated param ends in '.'
         if not param.endswith('.'):

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -130,7 +130,8 @@ class DictWrapper(object):
         metadata = self._response_dict.get('ResponseMetadata')
         if metadata:
             return metadata.RequestId
-        return self._response_dict.get('RequestId')
+        return self._response_dict.RequestId
+    
     @property
     def error(self):
         if 'Error' in self._response_dict:

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -370,7 +370,6 @@ class MWS(object):
     
     def enumerate_params(self, params=None):
         """
-        Similar to enumerate_params.
         Takes a dict of params:
             each key is a param to be enumerated
             each value is a list of values for that param.

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -131,6 +131,16 @@ class DictWrapper(object):
         if metadata:
             return metadata.RequestId
         return self._response_dict.get('RequestId')
+    @property
+    def error(self):
+        if 'Error' in self._response_dict:
+            return self._response_dict.Error
+        return None
+    
+    def is_error(self):
+        if self._response_dict.get('Error'):
+            return True
+        return False
 
 
 class DataWrapper(object):


### PR DESCRIPTION
Defined new `is_error()` method and `error` property (synonymous with `Error` attribute, just in lowercase for [minor] ease of use).

When request is made, user should test for `is_error()` where previously they may have caught `MWSError` exception. They can then work on the error message provided in `response.error.Message`, its code in `.Code`, etc.
