### PR TITLE
Updated invalid_items processing

### DIFF
--- a/mws/mws.py
+++ b/mws/mws.py
@@ -127,7 +127,12 @@ class DictWrapper(object):
             match = match.groups()[0]
             split_matches = match.strip('()').split('), (')
             
-            results = [dict(dict_pattern.findall(x)) for x in split_matches]
+            results = []
+            for x in split_matches:
+                result = dict(dict_pattern.findall(x))
+                result = {k: v.rstrip(',') for k, v in result.items()}
+                results.append(result)
+            
             self.invalid_items = results or None
     
     

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -969,6 +969,23 @@ class Products(MWS):
         return self.make_request(data)
     
     
+    def get_lowest_priced_offers_for_sku(self, marketplaceid, sku, condition="New", excludeme="False"):
+        data = dict(Action='GetLowestPricedOffersForSKU',
+                    MarketplaceId=marketplaceid,
+                    SellerSKU=sku,
+                    ItemCondition=condition,
+                    ExcludeMe=excludeme)
+        return self.make_request(data)
+
+    def get_lowest_priced_offers_for_asin(self, marketplaceid, asin, condition="New", excludeme="False"):
+        data = dict(Action='GetLowestPricedOffersForASIN',
+                    MarketplaceId=marketplaceid,
+                    ASIN=asin,
+                    ItemCondition=condition,
+                    ExcludeMe=excludeme)
+        return self.make_request(data)
+    
+    
     def get_product_categories_for_sku(self, marketplaceid, sku):
         data = dict(
             Action='GetProductCategoriesForSKU',


### PR DESCRIPTION
- Now strips a trailing comma, which is left behind after regex patterns do their thing.
- Expanded from a single list comprehension into a more complex for loop to get the job done without jamming the whole line full of code.

Secondary: added methods from upstream manually
- Refer to https://github.com/czpython/python-amazon-mws/pull/38
