### PR TITLE
Bugfix: ensure unique lists for certain operations

### DIFF
--- a/mws/mws.py
+++ b/mws/mws.py
@@ -105,6 +105,18 @@ def remove_namespace(xml):
     return out
 
 
+def unique_list_order_preserved(seq):
+    """
+    Returns a unique list of items from the sequence
+    while preserving original ordering.
+    The first occurence of an item is returned in the new sequence:
+    any subsequent occurrences of the same item are ignored.
+    """
+    seen = set()
+    seen_add = seen.add
+    return [x for x in seq if not (x in seen or seen_add(x))]
+
+
 class DictWrapper(object):
     def __init__(self, xml, rootkey=None):
         self.original = xml
@@ -1382,6 +1394,9 @@ class InboundShipments(MWS):
         """
         country_code = country_code or 'US'
         
+        # 'skus' should be a unique list, or there may be an error returned.
+        skus = unique_list_order_preserved(skus)
+        
         data = dict(
             Action='GetPrepInstructionsForSKU',
             ShipToCountryCode=country_code,
@@ -1398,6 +1413,9 @@ class InboundShipments(MWS):
         item sourcing decisions.
         """
         country_code = country_code or 'US'
+        
+        # 'asins' should be a unique list, or there may be an error returned.
+        asins = unique_list_order_preserved(asins)
         
         data = dict(
             Action='GetPrepInstructionsForASIN',


### PR DESCRIPTION
- Function unique_list_order_preserved is now available.
- This function is being used in get_prep_instructions_for_sku and get_prep_instructions_for_asin to ensure unique lists of items.
