### PR TITLE
Update to invalid items pattern

### DIFF
--- a/mws/mws.py
+++ b/mws/mws.py
@@ -135,7 +135,7 @@ class DictWrapper(object):
             if message:
                 message = message['value']
             
-            invalid_pattern = re.compile(r'InvalidItems\[\s*(.*)\]')
+            invalid_pattern = re.compile(r'InvalidItems\[\s*(.*)\]?')
             dict_pattern = re.compile(r'(\S+)=(".*?"|\S+)')
             
             match = invalid_pattern.search(message)


### PR DESCRIPTION
Found examples where this pattern doesn't work if Amazon somehow forgets to include `]` at the end. Adding `?` corrects for this.
