### PR TITLE
Assign Code dict to Message directly.

### DIFF
--- a/mws/mws.py
+++ b/mws/mws.py
@@ -185,10 +185,7 @@ class DictWrapper(object):
         if 'Error' in self._response_dict:
             error_dict = self._response_dict.Error
             if 'Message' not in error_dict:
-                code = error_dict.get('Code', '')
-                if code:
-                    code = code['value']
-                error_dict['Message'] = code
+                error_dict['Message'] = error_dict.get('Code')
             return error_dict
         return None
     


### PR DESCRIPTION
Doing this instead of assigning the code['value'], which runs risk of having a later process check for the Message's 'value' key. Since it would be a string at that point, that raises TypeError for wrong type of index (string instead of integer).

Other processes already check `if message` before getting the value of that message, so this should fix the issue downstream.
